### PR TITLE
feature: add optional parameter authPlugin to create MySQL user

### DIFF
--- a/apis/mysql/v1alpha1/user_types.go
+++ b/apis/mysql/v1alpha1/user_types.go
@@ -49,6 +49,10 @@ type UserParameters struct {
 	// BinLog defines whether the create, delete, update operations of this user are propagated to replicas. Defaults to true
 	// +optional
 	BinLog *bool `json:"binlog,omitempty"`
+
+	// AuthPlugin defines the MySQL authentication plugin (e.g., mysql_native_password, caching_sha2_password, AWSAuthenticationPlugin).
+	// +optional
+	AuthPlugin string `json:"authPlugin,omitempty"`
 }
 
 // ResourceOptions define the account specific resource limits.

--- a/package/crds/mysql.sql.crossplane.io_users.yaml
+++ b/package/crds/mysql.sql.crossplane.io_users.yaml
@@ -71,6 +71,14 @@ spec:
                 description: UserParameters define the desired state of a MySQL user
                   instance.
                 properties:
+                  authPlugin:
+                    description: |-
+                      AuthPlugin defines the MySQL authentication plugin (e.g., mysql_native_password, caching_sha2_password, AWSAuthenticationPlugin).
+                    type: string
+                    enum:
+                    - mysql_native_password
+                    - caching_sha2_password
+                    - AWSAuthenticationPlugin
                   binlog:
                     description: BinLog defines whether the create, delete, update
                       operations of this user are propagated to replicas. Defaults

--- a/pkg/clients/mysql/mysql_test.go
+++ b/pkg/clients/mysql/mysql_test.go
@@ -13,6 +13,7 @@ func TestDSNURLEscaping(t *testing.T) {
 	rawPass := "password^"
 	tls := "true"
 	binlog := false
+	authPlugin := "mysql_native_password"
 	dsn := DSN(user, rawPass, endpoint, port, tls, &binlog)
 	if dsn != fmt.Sprintf("%s:%s@tcp(%s:%s)/?tls=%s&sql_log_bin=%s",
 		user,

--- a/pkg/controller/mysql/user/reconciler.go
+++ b/pkg/controller/mysql/user/reconciler.go
@@ -56,6 +56,7 @@ const (
 	errUpdateUser              = "cannot update user"
 	errGetPasswordSecretFailed = "cannot get password secret"
 	errCompareResourceOptions  = "cannot compare desired and observed resource options"
+	errAuthPluginNotSupported  = "auth plugin not supported"
 
 	maxConcurrency = 5
 )
@@ -259,7 +260,10 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	ro := resourceOptionsToClauses(cr.Spec.ForProvider.ResourceOptions)
-	if err := c.executeCreateUserQuery(ctx, username, host, ro, pw); err != nil {
+
+	authplugin := cr.Spec.ForProvider.AuthPlugin
+
+	if err := c.executeCreateUserQuery(ctx, username, host, ro, pw, authplugin); err != nil {
 		return managed.ExternalCreation{}, err
 	}
 
@@ -272,17 +276,30 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}, nil
 }
 
-func (c *external) executeCreateUserQuery(ctx context.Context, username string, host string, resourceOptionsClauses []string, pw string) error {
+func (c *external) executeCreateUserQuery(ctx context.Context, username string, host string, resourceOptionsClauses []string, pw string, authplugin string) error {
 	resourceOptions := ""
 	if len(resourceOptionsClauses) != 0 {
 		resourceOptions = fmt.Sprintf(" WITH %s", strings.Join(resourceOptionsClauses, " "))
 	}
 
+	var authStm string
+
+	if len(authplugin) > 0 {
+		switch authplugin {
+			case "mysql_native_password", "caching_sha2_password":
+				authStm = fmt.Sprintf("WITH %s BY %s", authplugin, mysql.QuoteValue(pw))
+			case "AWSAuthenticationPlugin":
+				authStm = fmt.Sprintf("WITH %s AS %s", authplugin, mysql.QuoteValue("RDS"))
+		}
+	} else {
+		authStm = fmt.Sprintf("BY %s", mysql.QuoteValue(pw))
+	}
+
 	query := fmt.Sprintf(
-		"CREATE USER %s@%s IDENTIFIED BY %s%s",
+		"CREATE USER %s@%s IDENTIFIED %s%s",
 		mysql.QuoteValue(username),
 		mysql.QuoteValue(host),
-		mysql.QuoteValue(pw),
+		authStm,
 		resourceOptions,
 	)
 


### PR DESCRIPTION
### Description of your changes

This pull request adds the ability to specify an authentication plugin when creating MySQL users. This enhancement allows users to define which authentication method should be used, providing greater flexibility and compatibility with various MySQL setups. 
Supported Authentication Plugins: `mysql_native_password`, `caching_sha2_password`, `AWSAuthenticationPlugin`.

Fixes #106


### How has this code been tested
Unit tests updated (with setup ). 
Tested locally with all supported plugins.
